### PR TITLE
Make it safe to call uninit() multiple times.

### DIFF
--- a/drivers/src/nrfx_adc.c
+++ b/drivers/src/nrfx_adc.c
@@ -154,7 +154,10 @@ void nrfx_adc_all_channels_disable(void)
 
 void nrfx_adc_sample(void)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_cb.state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     NRFX_ASSERT(!nrf_adc_busy_check());
     nrf_adc_task_trigger(NRF_ADC_TASK_START);
 }

--- a/drivers/src/nrfx_clock.c
+++ b/drivers/src/nrfx_clock.c
@@ -208,7 +208,10 @@ void nrfx_clock_disable(void)
 
 void nrfx_clock_uninit(void)
 {
-    NRFX_ASSERT(m_clock_cb.module_initialized);
+    if (!m_clock_cb.module_initialized)
+    {
+        return;
+    }
     nrfx_clock_lfclk_stop();
     nrfx_clock_hfclk_stop();
     m_clock_cb.module_initialized = false;

--- a/drivers/src/nrfx_comp.c
+++ b/drivers/src/nrfx_comp.c
@@ -145,7 +145,10 @@ nrfx_err_t nrfx_comp_init(nrfx_comp_config_t const * p_config,
 
 void nrfx_comp_uninit(void)
 {
-    NRFX_ASSERT(m_state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     NRFX_IRQ_DISABLE(COMP_LPCOMP_IRQn);
     nrf_comp_disable();
 #if NRFX_CHECK(NRFX_PRS_ENABLED)

--- a/drivers/src/nrfx_gpiote.c
+++ b/drivers/src/nrfx_gpiote.c
@@ -263,7 +263,10 @@ bool nrfx_gpiote_is_init(void)
 
 void nrfx_gpiote_uninit(void)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_cb.state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     uint32_t i;
 

--- a/drivers/src/nrfx_i2s.c
+++ b/drivers/src/nrfx_i2s.c
@@ -183,7 +183,10 @@ nrfx_err_t nrfx_i2s_init(nrfx_i2s_config_t const * p_config,
 
 void nrfx_i2s_uninit(void)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_cb.state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     nrfx_i2s_stop();
 

--- a/drivers/src/nrfx_lpcomp.c
+++ b/drivers/src/nrfx_lpcomp.c
@@ -133,7 +133,10 @@ nrfx_err_t nrfx_lpcomp_init(nrfx_lpcomp_config_t const * p_config,
 
 void nrfx_lpcomp_uninit(void)
 {
-    NRFX_ASSERT(m_state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     NRFX_IRQ_DISABLE(LPCOMP_IRQn);
     nrfx_lpcomp_disable();
 #if NRFX_CHECK(NRFX_PRS_ENABLED)

--- a/drivers/src/nrfx_nfct.c
+++ b/drivers/src/nrfx_nfct.c
@@ -67,7 +67,7 @@ typedef struct
 #endif // NRF52840_XXAA
 #define NRFX_NFCT_TIMER_INSTANCE         4    /**< Timer instance used for various workarounds for the NFCT HW issues.*/
 
-static nrfx_nfct_timer_workaround_t m_timer_workaround = 
+static nrfx_nfct_timer_workaround_t m_timer_workaround =
 {
     .timer = NRFX_TIMER_INSTANCE(NRFX_NFCT_TIMER_INSTANCE),
 };
@@ -261,7 +261,7 @@ static void nrfx_nfct_field_event_handler(volatile nrfx_nfct_field_state_t field
 #elif defined(NRF52832_XXAA) || defined(NRF52832_XXAB)
                 nrfx_timer_clear(&m_timer_workaround.timer);
                 nrfx_timer_enable(&m_timer_workaround.timer);
-                m_timer_workaround.field_state_cnt = 0;  
+                m_timer_workaround.field_state_cnt = 0;
 #endif // NRF52840_XXAA
 
                 m_nfct_cb.field_on = true;
@@ -400,7 +400,7 @@ static void nrfx_nfct_field_timer_handler(nrf_timer_event_t event_type, void * p
 static inline nrfx_err_t nrfx_nfct_field_timer_config(void)
 {
     nrfx_err_t          err_code;
-    nrfx_timer_config_t timer_cfg = 
+    nrfx_timer_config_t timer_cfg =
     {
         .frequency          = NRF_TIMER_FREQ_1MHz,
         .mode               = NRF_TIMER_MODE_TIMER,
@@ -496,6 +496,10 @@ nrfx_err_t nrfx_nfct_init(nrfx_nfct_config_t const * p_config)
 
 void nrfx_nfct_uninit(void)
 {
+    if (m_nfct_cb.state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     nrfx_nfct_disable();
 
 #ifdef USE_TIMER_WORKAROUND
@@ -701,7 +705,7 @@ nrfx_err_t nrfx_nfct_nfcid1_default_bytes_get(uint8_t * const p_nfcid1_buff,
             p_nfcid1_buff[9] = (uint8_t) (nfc_tag_header2 >> 16);
         }
         /* Begin: Bugfix for FTPAN-181. */
-        /* Workaround for wrong value in NFCID1. Value 0x88 cannot be used as byte 3 
+        /* Workaround for wrong value in NFCID1. Value 0x88 cannot be used as byte 3
            of a double-size NFCID1, according to the NFC Forum Digital Protocol specification. */
         else if (p_nfcid1_buff[3] == 0x88)
         {
@@ -747,7 +751,7 @@ void nrfx_nfct_irq_handler(void)
     if (NRFX_NFCT_EVT_ACTIVE(FIELDLOST))
     {
         nrf_nfct_event_clear(NRF_NFCT_EVENT_FIELDLOST);
-        current_field = (current_field == NRFX_NFC_FIELD_STATE_NONE) ? 
+        current_field = (current_field == NRFX_NFC_FIELD_STATE_NONE) ?
                         NRFX_NFC_FIELD_STATE_OFF : NRFX_NFC_FIELD_STATE_UNKNOWN;
 
         NRFX_LOG_DEBUG("Field lost");
@@ -776,7 +780,7 @@ void nrfx_nfct_irq_handler(void)
 
         if (NRFX_NFCT_EVT_ACTIVE(RXERROR))
         {
-            nfct_evt.params.rx_frameend.rx_status = 
+            nfct_evt.params.rx_frameend.rx_status =
                 (nrf_nfct_rx_frame_status_get() & NRFX_NFCT_FRAME_STATUS_RX_ALL_MASK);
             nrf_nfct_event_clear(NRF_NFCT_EVENT_RXERROR);
 
@@ -814,7 +818,7 @@ void nrfx_nfct_irq_handler(void)
     if (NRFX_NFCT_EVT_ACTIVE(SELECTED))
     {
         nrf_nfct_event_clear(NRF_NFCT_EVENT_SELECTED);
-        /* Clear also RX END and RXERROR events because SW does not take care of 
+        /* Clear also RX END and RXERROR events because SW does not take care of
            commands that were received before selecting the tag. */
         nrf_nfct_event_clear(NRF_NFCT_EVENT_RXFRAMEEND);
         nrf_nfct_event_clear(NRF_NFCT_EVENT_RXERROR);

--- a/drivers/src/nrfx_pdm.c
+++ b/drivers/src/nrfx_pdm.c
@@ -226,6 +226,10 @@ nrfx_err_t nrfx_pdm_init(nrfx_pdm_config_t const * p_config,
 
 void nrfx_pdm_uninit(void)
 {
+    if (m_cb.drv_state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     nrf_pdm_disable();
     nrf_pdm_psel_disconnect();
     m_cb.drv_state = NRFX_DRV_STATE_UNINITIALIZED;

--- a/drivers/src/nrfx_power.c
+++ b/drivers/src/nrfx_power.c
@@ -117,7 +117,10 @@ nrfx_err_t nrfx_power_init(nrfx_power_config_t const * p_config)
 
 void nrfx_power_uninit(void)
 {
-    NRFX_ASSERT(m_initialized);
+    if (!m_initialized)
+    {
+        return;
+    }
 
 #if NRFX_CHECK(NRFX_CLOCK_ENABLED)
     if (!nrfx_clock_irq_enabled)

--- a/drivers/src/nrfx_pwm.c
+++ b/drivers/src/nrfx_pwm.c
@@ -176,7 +176,10 @@ nrfx_err_t nrfx_pwm_init(nrfx_pwm_t const * const p_instance,
 void nrfx_pwm_uninit(nrfx_pwm_t const * const p_instance)
 {
     pwm_control_block_t * p_cb  = &m_cb[p_instance->drv_inst_idx];
-    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_instance->p_registers));
 #if defined(USE_DMA_ISSUE_WORKAROUND)

--- a/drivers/src/nrfx_qdec.c
+++ b/drivers/src/nrfx_qdec.c
@@ -153,7 +153,10 @@ nrfx_err_t nrfx_qdec_init(nrfx_qdec_config_t const * p_config,
 
 void nrfx_qdec_uninit(void)
 {
-    NRFX_ASSERT(m_state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     nrfx_qdec_disable();
     NRFX_IRQ_DISABLE(QDEC_IRQn);
     m_state = NRFX_DRV_STATE_UNINITIALIZED;

--- a/drivers/src/nrfx_qspi.c
+++ b/drivers/src/nrfx_qspi.c
@@ -250,7 +250,10 @@ nrfx_err_t nrfx_qspi_mem_busy_check(void)
 
 void nrfx_qspi_uninit(void)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_cb.state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+       return;
+    }
 
     nrf_qspi_int_disable(NRF_QSPI, NRF_QSPI_INT_READY_MASK);
 

--- a/drivers/src/nrfx_rng.c
+++ b/drivers/src/nrfx_rng.c
@@ -89,7 +89,9 @@ void nrfx_rng_stop(void)
 
 void nrfx_rng_uninit(void)
 {
-    NRFX_ASSERT(m_rng_state == NRFX_DRV_STATE_INITIALIZED);
+    if (m_rng_state == NRFX_DRV_STATE_UNINITIALIZED) {
+        return;
+    }
 
     nrf_rng_int_disable(NRF_RNG_INT_VALRDY_MASK);
     nrf_rng_task_trigger(NRF_RNG_TASK_STOP);

--- a/drivers/src/nrfx_rtc.c
+++ b/drivers/src/nrfx_rtc.c
@@ -98,13 +98,16 @@ nrfx_err_t nrfx_rtc_init(nrfx_rtc_t const * const  p_instance,
 
 void nrfx_rtc_uninit(nrfx_rtc_t const * const p_instance)
 {
+    if (m_cb[p_instance->instance_id].state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     uint32_t mask = NRF_RTC_INT_TICK_MASK     |
                     NRF_RTC_INT_OVERFLOW_MASK |
                     NRF_RTC_INT_COMPARE0_MASK |
                     NRF_RTC_INT_COMPARE1_MASK |
                     NRF_RTC_INT_COMPARE2_MASK |
                     NRF_RTC_INT_COMPARE3_MASK;
-    NRFX_ASSERT(m_cb[p_instance->instance_id].state != NRFX_DRV_STATE_UNINITIALIZED);
 
     NRFX_IRQ_DISABLE(p_instance->irq);
 

--- a/drivers/src/nrfx_saadc.c
+++ b/drivers/src/nrfx_saadc.c
@@ -248,7 +248,10 @@ nrfx_err_t nrfx_saadc_init(nrfx_saadc_config_t const * p_config,
 
 void nrfx_saadc_uninit(void)
 {
-    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (m_cb.state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     nrf_saadc_int_disable(NRF_SAADC_INT_ALL);
     NRFX_IRQ_DISABLE(SAADC_IRQn);

--- a/drivers/src/nrfx_spi.c
+++ b/drivers/src/nrfx_spi.c
@@ -193,7 +193,10 @@ nrfx_err_t nrfx_spi_init(nrfx_spi_t const * const  p_instance,
 void nrfx_spi_uninit(nrfx_spi_t const * const p_instance)
 {
     spi_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     if (p_cb->handler)
     {

--- a/drivers/src/nrfx_spim.c
+++ b/drivers/src/nrfx_spim.c
@@ -341,7 +341,10 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
 void nrfx_spim_uninit(nrfx_spim_t const * const p_instance)
 {
     spim_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     if (p_cb->handler)
     {

--- a/drivers/src/nrfx_timer.c
+++ b/drivers/src/nrfx_timer.c
@@ -116,6 +116,10 @@ nrfx_err_t nrfx_timer_init(nrfx_timer_t const * const  p_instance,
 
 void nrfx_timer_uninit(nrfx_timer_t const * const p_instance)
 {
+    if (m_cb[p_instance->instance_id].state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     NRFX_IRQ_DISABLE(nrfx_get_irq_number(p_instance->p_reg));
 
     #define DISABLE_ALL UINT32_MAX

--- a/drivers/src/nrfx_twi.c
+++ b/drivers/src/nrfx_twi.c
@@ -195,7 +195,10 @@ nrfx_err_t nrfx_twi_init(nrfx_twi_t const *        p_instance,
 void nrfx_twi_uninit(nrfx_twi_t const * p_instance)
 {
     twi_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     if (p_cb->handler)
     {

--- a/drivers/src/nrfx_twim.c
+++ b/drivers/src/nrfx_twim.c
@@ -213,7 +213,10 @@ nrfx_err_t nrfx_twim_init(nrfx_twim_t const *        p_instance,
 void nrfx_twim_uninit(nrfx_twim_t const * p_instance)
 {
     twim_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     if (p_cb->handler)
     {

--- a/drivers/src/nrfx_twis.c
+++ b/drivers/src/nrfx_twis.c
@@ -546,7 +546,10 @@ void nrfx_twis_uninit(nrfx_twis_t const * p_instance)
 {
     NRF_TWIS_Type *        p_reg = p_instance->p_reg;
     twis_control_block_t * p_cb  = &m_cb[p_instance->drv_inst_idx];
-    NRFX_ASSERT(p_cb->state != NRFX_DRV_STATE_UNINITIALIZED);
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     TWIS_PSEL_Type psel = p_reg->PSEL;
 

--- a/drivers/src/nrfx_uart.c
+++ b/drivers/src/nrfx_uart.c
@@ -213,6 +213,10 @@ nrfx_err_t nrfx_uart_init(nrfx_uart_t const *        p_instance,
 void nrfx_uart_uninit(nrfx_uart_t const * p_instance)
 {
     uart_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     nrf_uart_disable(p_instance->p_reg);
 

--- a/drivers/src/nrfx_uarte.c
+++ b/drivers/src/nrfx_uarte.c
@@ -233,7 +233,10 @@ nrfx_err_t nrfx_uarte_init(nrfx_uarte_t const *        p_instance,
 void nrfx_uarte_uninit(nrfx_uarte_t const * p_instance)
 {
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
-
+    if (p_cb->state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
     nrf_uarte_disable(p_instance->p_reg);
 
     if (p_cb->handler)

--- a/drivers/src/nrfx_usbd.c
+++ b/drivers/src/nrfx_usbd.c
@@ -1197,7 +1197,7 @@ static void ev_setup_handler(void)
     }
 
     m_last_setup_dir =
-        ((bmRequestType & USBD_BMREQUESTTYPE_DIRECTION_Msk) == 
+        ((bmRequestType & USBD_BMREQUESTTYPE_DIRECTION_Msk) ==
          (USBD_BMREQUESTTYPE_DIRECTION_HostToDevice << USBD_BMREQUESTTYPE_DIRECTION_Pos)) ?
         NRFX_USBD_EPOUT0 : NRFX_USBD_EPIN0;
 
@@ -1658,7 +1658,7 @@ void nrfx_usbd_irq_handler(void)
 nrfx_err_t nrfx_usbd_init(nrfx_usbd_event_handler_t event_handler)
 {
     NRFX_ASSERT((nrfx_usbd_errata_type_52840_eng_a() ||
-                 nrfx_usbd_errata_type_52840_eng_b() || 
+                 nrfx_usbd_errata_type_52840_eng_b() ||
                  nrfx_usbd_errata_type_52840_eng_c() ||
                  nrfx_usbd_errata_type_52840_eng_d())
                );
@@ -1700,7 +1700,10 @@ nrfx_err_t nrfx_usbd_init(nrfx_usbd_event_handler_t event_handler)
 
 void nrfx_usbd_uninit(void)
 {
-    NRFX_ASSERT(m_drv_state == NRFX_DRV_STATE_INITIALIZED);
+    if (m_drv_state == NRFX_DRV_STATE_UNINITIALIZED)
+    {
+        return;
+    }
 
     m_event_handler = NULL;
     m_drv_state = NRFX_DRV_STATE_UNINITIALIZED;
@@ -1729,7 +1732,7 @@ void nrfx_usbd_enable(void)
         }
         NRFX_CRITICAL_SECTION_EXIT();
     }
-    
+
     if (nrfx_usbd_errata_171())
     {
         NRFX_CRITICAL_SECTION_ENTER();
@@ -1754,7 +1757,7 @@ void nrfx_usbd_enable(void)
         /* Empty loop */
     }
     nrf_usbd_eventcause_clear(NRF_USBD_EVENTCAUSE_READY_MASK);
-    
+
     if (nrfx_usbd_errata_171())
     {
         NRFX_CRITICAL_SECTION_ENTER();


### PR DESCRIPTION
Addresses https://github.com/NordicSemiconductor/nrfx/issues/43 for us: `uninit()` cannot be called safely when `DEBUG` is set if the nrfx driver object is already uninitialized.

Also discussed in https://devzone.nordicsemi.com/f/nordic-q-a/39433/nrfx_-_uninit-not-idempotent-can-t-be-safely-called-on-an-already-uninitialized-driver-instance.